### PR TITLE
fix: loosen peerDependency requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "precommit-hook": "^3.0.0"
   },
   "peerDependencies": {
-    "postcss": "4.x",
-    "postcss-modules-extract-imports": "0.x",
-    "postcss-modules-local-by-default": "0.x",
-    "postcss-modules-scope": "0.x"
+    "postcss": ">=4.x",
+    "postcss-modules-extract-imports": ">=0.x",
+    "postcss-modules-local-by-default": ">=0.x",
+    "postcss-modules-scope": ">=0.x"
   },
   "scripts": {
     "start": "esw -w .",


### PR DESCRIPTION
With postcss v5 out, there's a need for this, and there's no real reason to lock down the dependency AFAIK.