### PR TITLE
Add ability to attach the hook to additional extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ npm i css-modules-require-hook
  * `string`   **rootDir** &mdash; absolute path to the project directory. Providing this will result in better generated class names. It can be obligatory, if you run require hook and build tools (like [css-modulesify](https://github.com/css-modules/css-modulesify)) from different working directories.
  * `string`   **to** &mdash; provides `to` option to the [LazyResult instance](https://github.com/postcss/postcss/blob/master/docs/api.md#processorprocesscss-opts).
  * `array`    **use** &mdash; custom subset of postcss plugins.
+ * `array`    **extensions** &mdash; attach the hook to additional file extensions (for example `['.scss']`).
 
 ### Examples
 

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,8 +1,9 @@
 /**
  * @param {function} compile
+ * @param {string} extension
  */
-export default function attachHook(compile) {
-  require.extensions['.css'] = function hook(m, filename) {
+export default function attachHook(compile, extension) {
+  require.extensions[extension] = function hook(m, filename) {
     const tokens = compile(filename);
     return m._compile('module.exports = ' + JSON.stringify(tokens), filename);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ let rootDir = process.cwd();
  * @param  {string}   opts.rootDir
  * @param  {string}   opts.to
  * @param  {array}    opts.use
+ * @param  {array}    opts.extensions
  */
 export default function setup(opts = {}) {
   // clearing cache
@@ -63,6 +64,13 @@ export default function setup(opts = {}) {
   plugins.push(generateScopedName
     ? new Scope({generateScopedName: opts.generateScopedName})
     : Scope);
+
+  const extraExtensions = get('extensions', null, 'array', opts);
+  if (extraExtensions) {
+    extraExtensions.forEach((extension) => {
+      hook(filename => fetch(filename, filename), extension);
+    });
+  }
 }
 
 /**
@@ -104,4 +112,4 @@ function fetch(_to, _from, _trace) {
   return tokens;
 }
 
-hook(filename => fetch(filename, filename));
+hook(filename => fetch(filename, filename), '.css');

--- a/test/common-test-cases.js
+++ b/test/common-test-cases.js
@@ -219,6 +219,19 @@ describe('common-test-cases', () => {
       });
     });
 
+    describe('extra extension', () => {
+      before(() => {
+        expectedTokens = JSON.parse(readFileSync(resolve('test/test-cases/extra-extension/expected.json'), 'utf8'));
+        hook({extensions: ['.scss']})
+      });
+
+      it('require-hook', () => {
+        const tokens = require(resolve('test/test-cases/extra-extension/source.scss'));
+        equal(JSON.stringify(tokens), JSON.stringify(expectedTokens));
+      });
+
+    });
+
   });
 
 });

--- a/test/test-cases/extra-extension/expected.json
+++ b/test/test-cases/extra-extension/expected.json
@@ -1,0 +1,3 @@
+{
+  "localName": "_test_test_cases_extra_extension_source__localName"
+}

--- a/test/test-cases/extra-extension/source.scss
+++ b/test/test-cases/extra-extension/source.scss
@@ -1,0 +1,5 @@
+$color: orange;
+
+.localName {
+  color: $color;
+}


### PR DESCRIPTION
I use CSS Modules with Sass and I need this functionality to test components with CSS modules. 

```javascript
var hook = require('css-modules-require-hook');

hook({
  extension: ['.scss']
});
```
