### PR TITLE
Fix extension option when used with custom plugins list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,13 @@ export default function setup(opts = {}) {
   // https://github.com/postcss/postcss/blob/master/docs/api.md#processorprocesscss-opts
   lazyResultOpts = pick(opts, ['to']);
 
+  const extraExtensions = get('extensions', null, 'array', opts);
+  if (extraExtensions) {
+    extraExtensions.forEach((extension) => {
+      hook(filename => fetch(filename, filename), extension);
+    });
+  }
+
   const customPlugins = get('use', ['u'], 'array', opts);
   if (customPlugins) {
     return void (plugins = customPlugins);
@@ -66,13 +73,6 @@ export default function setup(opts = {}) {
   plugins.push(generateScopedName
     ? new Scope({generateScopedName: opts.generateScopedName})
     : Scope);
-
-  const extraExtensions = get('extensions', null, 'array', opts);
-  if (extraExtensions) {
-    extraExtensions.forEach((extension) => {
-      hook(filename => fetch(filename, filename), extension);
-    });
-  }
 }
 
 /**

--- a/test/common-test-cases.js
+++ b/test/common-test-cases.js
@@ -2,6 +2,9 @@ import { equal } from 'assert';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { extend } from 'lodash';
+import ExtractImports from 'postcss-modules-extract-imports';
+import LocalByDefault from 'postcss-modules-local-by-default';
+import Scope from 'postcss-modules-scope';
 import FileSystemLoader from 'css-modules-loader-core/lib/file-system-loader';
 import hook from '../src';
 
@@ -219,10 +222,14 @@ describe('common-test-cases', () => {
       });
     });
 
-    describe('extra extension', () => {
+    describe('extra extension with custom plugins', () => {
       before(() => {
         expectedTokens = JSON.parse(readFileSync(resolve('test/test-cases/extra-extension/expected.json'), 'utf8'));
-        hook({extensions: ['.scss']})
+        hook({extensions: ['.scss'], use: [
+          ExtractImports,
+          LocalByDefault,
+          Scope,
+        ]});
       });
 
       it('require-hook', () => {

--- a/test/test-cases/extra-extension/source.scss
+++ b/test/test-cases/extra-extension/source.scss
@@ -1,4 +1,4 @@
-$color: orange;
+$color: #c0ffee;
 
 .localName {
   color: $color;


### PR DESCRIPTION
Didn’t notice a `return` statement yesterday. So when you specify the `use` option custom extensions don’t apply.

