### PR TITLE
Fix peerDependencies to allow PostCSS 5 to be used with recent plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   },
   "peerDependencies": {
     "postcss": ">=4.x",
-    "postcss-modules-extract-imports": ">=0.x",
-    "postcss-modules-local-by-default": ">=0.x",
-    "postcss-modules-scope": ">=0.x"
+    "postcss-modules-extract-imports": ">=0.x || ^1.0.0-beta",
+    "postcss-modules-local-by-default": ">=0.x || ^1.0.0-beta",
+    "postcss-modules-scope": ">=0.x || ^1.0.0-beta"
   },
   "scripts": {
     "start": "esw -w .",


### PR DESCRIPTION
A quick fix for commit cdb58ee3a429c302d466c36f84774a8296847e8b
Thank you