### PR TITLE
improve development mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ import './guard';
 
 // cache
 let tokensByFile = {};
-// global
+// globals;
+let debugMode = process.env.NODE_ENV !== 'development';
 let instance = extractor({}, fetch);
 let processorOptions = {};
 let preProcess = identity;
@@ -26,7 +27,7 @@ const debugSetup = debug('css-modules:setup');
  * @param  {string}   options.to
  * @param  {object}   options.rest
  */
-export default function setup({ extensions: extraExtensions, preprocessCss, processCss, to, ...rest } = {}) {
+export default function setup({ extensions: extraExtensions, preprocessCss, processCss, to, devMode,  ...rest } = {}) {
   debugSetup(arguments[0]);
   validate(arguments[0]);
   instance = extractor(rest, fetch);
@@ -35,6 +36,11 @@ export default function setup({ extensions: extraExtensions, preprocessCss, proc
   postProcess = processCss || null;
   // clearing cache
   tokensByFile = {};
+
+  // debug option is preferred NODE_ENV === 'development'
+  if (typeof devMode !== 'undefined') {
+    debugMode = devMode;
+  }
 
   if (extraExtensions) {
     extraExtensions.forEach((extension) => hook(filename => fetch(filename, filename), extension));
@@ -69,7 +75,7 @@ function fetch(to, from) {
 
   tokens = lazyResult.root.tokens;
 
-  if (process.env.NODE_ENV !== 'development') {
+  if (!debugMode) {
     // updating cache
     tokensByFile[filename] = tokens;
   } else {

--- a/test/cache.js
+++ b/test/cache.js
@@ -11,47 +11,91 @@ function updateFile(content) {
 }
 
 describe('development mode', () => {
-  describe('should cache calls not in development mode', () => {
-    before(() => {
-      hook();
-      updateFile('.block\n{\n  display: block;\n}');
-      process.env.NODE_ENV = '';
-      require(fixture);
-      updateFile('.inline-block\n{\n  display: inline-block;\n}');
+  describe('shouldn`t calls cache in development mode', () => {
+    describe('devMode:false options should override NODE_ENV="development"', () => {
+      before(() => {
+        hook({ devMode: false });
+        updateFile('.block\n{\n  display: block;\n}');
+        process.env.NODE_ENV = 'development';
+        require(fixture);
+        updateFile('.inline-block\n{\n  display: inline-block;\n}');
+      });
+
+      after(() => {
+        process.env.NODE_ENV = '';
+        dropCache(fixture);
+      });
+
+      it('should retrive data from cache', () => {
+        const tokens = require(fixture);
+        const keys = Object.keys(tokens);
+        equal(keys.length, 1);
+        equal(keys.join(''), 'block');
+      });
     });
 
-    after(() => {
-      process.env.NODE_ENV = '';
-      dropCache(fixture);
-    });
+    describe('should cache calls without any options', () => {
+      before(() => {
+        hook();
+        updateFile('.block\n{\n  display: block;\n}');
+        require(fixture);
+        updateFile('.inline-block\n{\n  display: inline-block;\n}');
+      });
 
-    it('should retrive data from cache', () => {
-      const tokens = require(fixture);
-      const keys = Object.keys(tokens);
-      equal(keys.length, 1);
-      equal(keys.join(''), 'block');
+      after(() => {
+        dropCache(fixture);
+      });
+
+      it('should retrive data from cache', () => {
+        const tokens = require(fixture);
+        const keys = Object.keys(tokens);
+        equal(keys.length, 1);
+        equal(keys.join(''), 'block');
+      });
     });
   });
 
   describe('should clear cache in development mode', () => {
-    before(() => {
-      hook();
-      updateFile('.block\n{\n  display: block;\n}');
-      process.env.NODE_ENV = 'development';
-      require(fixture);
-      updateFile('.inline-block\n{\n  display: inline-block;\n}');
+    describe('devMode:true option should works without NODE_ENV="development"', () => {
+      before(() => {
+        hook({ devMode: true });
+        updateFile('.block\n{\n  display: block;\n}');
+        require(fixture);
+        updateFile('.inline-block\n{\n  display: inline-block;\n}');
+      });
+
+      after(() => {
+        dropCache(fixture);
+      });
+
+      it('should retrive data from fs', () => {
+        const tokens = require(fixture);
+        const keys = Object.keys(tokens);
+        equal(keys.length, 1);
+        equal(keys.join(''), 'inline-block');
+      });
     });
 
-    after(() => {
-      process.env.NODE_ENV = '';
-      dropCache(fixture);
-    });
+    describe('NODE_ENV="development" should works without debug:true option', () => {
+      before(() => {
+        hook();
+        updateFile('.block\n{\n  display: block;\n}');
+        process.env.NODE_ENV = 'development';
+        require(fixture);
+        updateFile('.inline-block\n{\n  display: inline-block;\n}');
+      });
 
-    it('should retrive data from fs', () => {
-      const tokens = require(fixture);
-      const keys = Object.keys(tokens);
-      equal(keys.length, 1);
-      equal(keys.join(''), 'inline-block');
+      after(() => {
+        process.env.NODE_ENV = '';
+        dropCache(fixture);
+      });
+
+      it('should retrive data from fs', () => {
+        const tokens = require(fixture);
+        const keys = Object.keys(tokens);
+        equal(keys.length, 1);
+        equal(keys.join(''), 'inline-block');
+      });
     });
   });
 });


### PR DESCRIPTION
Just add devMode option to hooks.
So NODE_ENV="development" is still available to use. But new feature makes possible to clean cache without NODE_ENV
```js
hooks({
    // ... some initial options
    devMode: true // <------
})
```