### PR TITLE
Add option of adding camelize keys, like css-loader's camelCase

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const genericNames = require('generic-names');
 const globToRegex = require('glob-to-regexp');
 const identity = require('lodash').identity;
 const negate = require('lodash').negate;
+const camelCaseFunc = require('lodash').camelCase;
 const readFileSync = require('fs').readFileSync;
 const relative = require('path').relative;
 const resolve = require('path').resolve;
@@ -27,6 +28,7 @@ module.exports = function setupHook({
   preprocessCss = identity,
   processCss,
   processorOpts,
+  camelCase,
   append = [],
   prepend = [],
   createImportedName,
@@ -102,6 +104,11 @@ module.exports = function setupHook({
     lazyResult.warnings().forEach(message => console.warn(message.text));
 
     tokens = lazyResult.root.tokens;
+
+    if (camelCase) {
+      tokens = Object.assign({}, tokens,
+        ...Object.keys(tokens).map(key => ({ [camelCaseFunc(key)]: tokens[key] })))
+    }
 
     if (!debugMode) {
       // updating cache

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,6 +10,7 @@ const rules = {
   preprocessCss:      'function',
   processCss:         'function',
   processorOpts:      'object',
+  camelCase:          'boolean',
   // plugins
   append:             'array',
   prepend:            'array',

--- a/test/api/camelCase.js
+++ b/test/api/camelCase.js
@@ -1,6 +1,5 @@
 const detachHook = require('../sugar').detachHook;
 const dropCache = require('../sugar').dropCache;
-const identity = require('lodash').lodash;
 
 suite('api/camelCase', () => {
   test('should add camel case keys in token', () => {

--- a/test/api/camelCase.js
+++ b/test/api/camelCase.js
@@ -1,0 +1,20 @@
+const detachHook = require('../sugar').detachHook;
+const dropCache = require('../sugar').dropCache;
+const identity = require('lodash').lodash;
+
+suite('api/camelCase', () => {
+  test('should add camel case keys in token', () => {
+    const tokens = require('./fixture/bem.css');
+    assert.deepEqual(tokens, {
+      blockElementModifier: '_test_api_fixture_bem__block__element--modifier',
+      'block__element--modifier': '_test_api_fixture_bem__block__element--modifier',
+    });
+  });
+
+  setup(() => hook({ camelCase: true }));
+
+  teardown(() => {
+    detachHook('.css');
+    dropCache('./api/fixture/bem.css');
+  });
+});

--- a/test/api/fixture/bem.css
+++ b/test/api/fixture/bem.css
@@ -1,0 +1,3 @@
+.block__element--modifier {
+  background: #1e2a35;
+}


### PR DESCRIPTION
Hi,

Webpack's css-loader has a useful option to provide camelize key to the json output ([parameter `camelCase`](https://github.com/webpack/css-loader#camel-case)). Users of this option need this functionality in server-side require hook also to create isomorphic modules.

Now I'm working around with this issue via additional postcss plugin adding camelize keys to `:export` rule, but it would be nice to be able to do this here without additional dependencies.

Does this patch make sense to you?

Thanks.
