### PR TITLE
Fix non-relative pathname detection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ module.exports = function setupHook({
    */
   function fetch(_to, from) {
     // getting absolute path to the processing file
-    const filename = /\w/i.test(_to[0])
+    const filename = /[^\\/?%*:|"<>\.]/i.test(_to[0])
       ? require.resolve(_to)
       : resolve(dirname(from), _to);
 

--- a/test/tokens/cases/compose-node-module/expected.json
+++ b/test/tokens/cases/compose-node-module/expected.json
@@ -1,3 +1,4 @@
 {
-  "foo": "_test_tokens_cases_compose_node_module_source__foo _test_tokens_node_modules_awesome_theme_common__paragraph _test_tokens_node_modules_awesome_theme_oceanic__color"
+  "foo": "_test_tokens_cases_compose_node_module_source__foo _test_tokens_node_modules_awesome_theme_common__paragraph _test_tokens_node_modules_awesome_theme_oceanic__color",
+  "bar": "_test_tokens_cases_compose_node_module_source__bar _test_tokens_node_modules_privateorg_theme_common__button"
 }

--- a/test/tokens/cases/compose-node-module/source.css
+++ b/test/tokens/cases/compose-node-module/source.css
@@ -2,3 +2,8 @@
 {
   composes: paragraph from 'awesome-theme/common.css';
 }
+
+.bar
+{
+  composes: button from '@privateorg/theme/common.css';
+}

--- a/test/tokens/node_modules/@privateorg/theme/common.css
+++ b/test/tokens/node_modules/@privateorg/theme/common.css
@@ -1,0 +1,4 @@
+.button
+{
+  background: blue;
+}


### PR DESCRIPTION
When composing a style from a CSS file in a [scoped module](http://blog.npmjs.org/post/116936804365/solving-npms-hard-problem-naming-packages), the hook would previously not detect that this was not a relative path due to it starting with `@`. 

A quick trip to [StackOverflow](http://stackoverflow.com/a/6222235) later, I think this updated regex will now correctly detect all non-relative paths.