### PR TITLE
Add generic-names `hashPrefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Provides the full list of PostCSS plugins to the pipeline. Providing this cancel
 
 Short alias for the [postcss-modules-extract-imports](https://github.com/css-modules/postcss-modules-extract-imports) plugin's `createImportedName` option.
 
-### `generateScopedName` function
+### `generateScopedName` string|function
 
 Short alias for the [postcss-modules-scope](https://github.com/css-modules/postcss-modules-scope) plugin's option. Helps you to specify the custom way to build generic names for the class selectors.
 You may also use a string pattern similar to the webpack's [css-loader](https://github.com/webpack/css-loader#local-scope).

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ hook({
 });
 ```
 
+### `hashPrefix` string
+
+Short alias for the [generic-names](https://github.com/css-modules/generic-names) helper option.
+Provides additional hash uniqueness. Might be useful for projects with several stylesheets sharing a same name.
+
 ### `mode` string
 
 Short alias for the [postcss-modules-local-by-default](https://github.com/css-modules/postcss-modules-local-by-default) plugin's option.

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ module.exports = function setupHook({
   prepend = [],
   createImportedName,
   generateScopedName,
+  hashPrefix,
   mode,
   use,
   rootDir: context = process.cwd(),
@@ -51,7 +52,7 @@ module.exports = function setupHook({
   let scopedName;
   if (generateScopedName) {
     scopedName = typeof generateScopedName !== 'function'
-      ? genericNames(generateScopedName, {context}) //  for example '[name]__[local]___[hash:base64:5]'
+      ? genericNames(generateScopedName, {context, hashPrefix}) //  for example '[name]__[local]___[hash:base64:5]'
       : generateScopedName;
   } else {
     // small fallback

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -17,6 +17,7 @@ const rules = {
   use:                'array',
   createImportedName: 'function',
   generateScopedName: 'function|string',
+  hashPrefix:         'string',
   mode:               'string',
   rootDir:            'string',
 };

--- a/test/api/hashPrefix.js
+++ b/test/api/hashPrefix.js
@@ -1,0 +1,39 @@
+const detachHook = require('../sugar').detachHook;
+const dropCache = require('../sugar').dropCache;
+
+suite('api/hashPrefix', () => {
+  let samples = [];
+
+  suite('using string pattern and hashPrefix', () => {
+    let tokens;
+
+    test('should return tokens with prefixed id', () => assert.deepEqual(tokens, {
+      color: 'oceanic__color___3xlBZ',
+    }));
+
+    setup(() => {
+      hook({generateScopedName: '[name]__[local]___[hash:base64:5]', hashPrefix: 'test'});
+      tokens = require('./fixture/oceanic.css');
+      samples.push(tokens);
+    });
+  });
+
+  suite('using string pattern', () => {
+    let tokens;
+
+    test('should return tokens with different hashes', () => assert.notDeepEqual(
+      samples
+    ));
+
+    setup(() => {
+      hook({generateScopedName: '[name]__[local]___[hash:base64:5]'});
+      tokens = require('./fixture/oceanic.css');
+      samples.push(tokens);
+    });
+  });
+
+  teardown(() => {
+    detachHook('.css');
+    dropCache('./api/fixture/oceanic.css');
+  });
+});


### PR DESCRIPTION
Hi,

this PR allows to pass the [`hasPrefix`](https://github.com/css-modules/generic-names/blob/master/index.js#L19) option to `generic-names` directly, easier than building our own `generateScopedName` function and using that lib anyway.

Similar to Webpack css loader (undocumented) [`hashPrefix`](https://github.com/webpack/css-loader/blob/5a9c1d13940194b78bff0e27284836557f962e5b/lib/getLocalIdent.js#L12) query parameter.