### PR TITLE
Updated readme for babel-node and ES6 import

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ require('css-modules-require-hook/preset');
 // const styles = require('./icon.css');
 ```
 
+
+### Using with babel-node / ES6 Imports
+You will need to create a `cmrh.conf.js` file within the directory as you are importing `css-modules-require-hook`.
+
+
+```javascript
+// server.js
+import csshook from 'css-modules-require-hook/preset' // import hook before routes
+import routes from '/shared/views/routes'
+
+// create server, etc
+```
+
+```javascript
+// cmrh.conf.js
+module.exports = {
+  // Same scope name as in webpack build
+  generateScopedName: '[name]__[local]___[hash:base64:5]',
+}
+```
+
+
+
 ### Development mode
 
 Usually, Node.js caches all the `require` calls by default. In order to invalidate cache for the purpose of development you should set the environment variable `NODE_ENV` to `development`. For example:


### PR DESCRIPTION
It took me ages to figure out how to import this using babel-node. 

There seems to be some issue with `require`, `imports` and `babel-node` meaning that the hook doesn't get run until after it tries to import files+styles. (Or maybe I am just noob) See #53 

This worked as my solution, and might save someone else a lot of time :)
