### PR TITLE
add tokens to processCss function

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ hook({
   /**
    * @param  {string} css
    * @param  {string} filepath Absolute path to the file
+   * @param  {object} tokens
    */
-  processCss: function (css, filepath) { /* */ }
+  processCss: function (css, filepath, tokens) { /* */ }
 });
 ```
 

--- a/lib/attachHook.js
+++ b/lib/attachHook.js
@@ -13,7 +13,8 @@ module.exports = function attachHook(compile, extension, isException) {
       existingHook(m, filename);
     } else {
       const tokens = compile(filename);
-      return m._compile(`module.exports = ${JSON.stringify(tokens)}`, filename);
+
+      m.exports = tokens;
     }
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ module.exports = function setupHook({
   debugSetup(arguments[0]);
   validate(arguments[0]);
 
-  const tokensByFile = {};
+  const resultsByFile = {};
 
   // debug option is preferred NODE_ENV === 'development'
   const debugMode = typeof devMode !== 'undefined'
@@ -76,58 +76,73 @@ module.exports = function setupHook({
   const runner = postcss(plugins);
 
   /**
-   * @todo   think about replacing sequential fetch function calls with requires calls
    * @param  {string} _to
    * @param  {string} from
    * @return {object}
    */
   function fetch(_to, from) {
+    return runProcess(_to, from).tokens;
+  }
+
+  /**
+   * @param  {string} _to
+   * @param  {string} from
+   * @return {object}
+   */
+  function runProcess(_to, from) {
     // getting absolute path to the processing file
     const filename = /[^\\/?%*:|"<>\.]/i.test(_to[0])
       ? require.resolve(_to)
       : resolve(dirname(from), _to);
 
     // checking cache
-    let tokens = tokensByFile[filename];
-    if (tokens) {
+    let results = resultsByFile[filename];
+    if (results) {
       debugFetch(`${filename} → cache`);
-      debugFetch(tokens);
-      return tokens;
+      debugFetch(results.tokens);
+      return results;
     }
 
     const source = preprocessCss(readFileSync(filename, 'utf8'), filename);
     // https://github.com/postcss/postcss/blob/master/docs/api.md#processorprocesscss-opts
     const lazyResult = runner.process(source, assign({}, processorOpts, {from: filename}));
+    const css = lazyResult.css;
 
     // https://github.com/postcss/postcss/blob/master/docs/api.md#lazywarnings
     lazyResult.warnings().forEach(message => console.warn(message.text));
 
-    tokens = lazyResult.root.tokens;
+    results = {
+      tokens: lazyResult.root.tokens,
+      css: lazyResult.css,
+      filename
+    };
 
     if (!debugMode) {
       // updating cache
-      tokensByFile[filename] = tokens;
+      resultsByFile[filename] = results;
     } else {
       // clearing cache in development mode
       delete require.cache[filename];
     }
 
-    if (processCss) {
-      processCss(lazyResult.css, filename);
-    }
-
     debugFetch(`${filename} → fs`);
-    debugFetch(tokens);
+    debugFetch(results.tokens);
 
-    return tokens;
+    return results;
   };
 
   const exts = toArray(extensions);
   const isException = buildExceptionChecker(ignore);
 
   const hook = filename => {
-    const tokens = fetch(filename, filename);
-    return camelCase ? transformTokens(tokens, camelCase) : tokens;
+    const lazyResult = runProcess(filename, filename);
+    let tokens = camelCase ? transformTokens(lazyResult.tokens, camelCase) : lazyResult.tokens;
+
+    if (processCss) {
+      processCss(lazyResult.css, lazyResult.filename, tokens);
+    }
+
+    return tokens;
   };
 
   // @todo add possibility to specify particular config for each extension


### PR DESCRIPTION
Hi all! 🤚 
I am doing some hack with the `css-modules-require-hook` lib.
For my use case, I am needing to receive the tokens generated in the `processCss` function and then do some hack with that.
My first obstacle there is that it wasn't as easy as adding `tokens` to the `processCss` function since after that call, you are doing the `camelCase` transformation, so I had to move the `processCss` function where the `hook` happens and then do some refactor there to achieve that.
My second obstacle was that (I don't know why) you are doing `m._compile(`module.exports = ${JSON.stringify(tokens)}`, filename);` to return the tokens, and for my use case I was needing to add a function to that tokens. So I changed it to just `module.exports == tokens`. If you have a solid reason to do this compile, please let me know.

Let me know if this changes looks of for you and also if you need some change from my side.
Thanks in advance for your time. 👋  