### PR TITLE
noCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ Short alias for the [postcss-modules-local-by-default](https://github.com/css-mo
 
 Provides absolute path to the project directory. Providing this will result in better generated class names. It can be obligatory, if you run require hook and build tools (like [css-modulesify](https://github.com/css-modules/css-modulesify)) from different working directories.
 
+### `noCache` boolean
+
+Do not cache module. You may need this option if you want to watch files. But expect the performance degradation when you call require for same file multiple times.
+
 
 ## Debugging
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const debugSetup = require('debug')('css-modules:setup');
 module.exports = function setupHook({
   camelCase,
   devMode,
+  noCache,
   extensions = '.css',
   ignore,
   preprocessCss = identity,
@@ -87,11 +88,14 @@ module.exports = function setupHook({
       : resolve(dirname(from), _to);
 
     // checking cache
-    let tokens = tokensByFile[filename];
-    if (tokens) {
-      debugFetch(`${filename} → cache`);
-      debugFetch(tokens);
-      return tokens;
+    let tokens;
+    if (!noCache) {
+      tokens = tokensByFile[filename];
+      if (tokens) {
+        debugFetch(`${filename} → cache`);
+        debugFetch(tokens);
+        return tokens;
+      }
     }
 
     const source = preprocessCss(readFileSync(filename, 'utf8'), filename);
@@ -103,11 +107,11 @@ module.exports = function setupHook({
 
     tokens = lazyResult.root.exports || {};
 
-    if (!debugMode)
+    if (!debugMode && !noCache)
       // updating cache
       tokensByFile[filename] = tokens;
     else
-      // clearing cache in development mode
+      // clearing cache in development mode or with noCache option
       delete require.cache[filename];
 
     if (processCss)

--- a/src/validate.js
+++ b/src/validate.js
@@ -30,6 +30,7 @@ const rules = {
   hashPrefix: 'string',
   mode: 'string',
   rootDir: 'string',
+  noCache: 'boolean',
 };
 
 const tests = {


### PR DESCRIPTION
I'm trying to use this tool with [babel-plugin-css-modules-transform](https://github.com/michalkvasnicak/babel-plugin-css-modules-transform) and gulp-watch, thus it is about the process staying alive. The problem is `require` caches initial file module and after file source changes, an output will be the same.

This PR solves the problem. Now you can specify option `noCache` and join the watching.