### PR TITLE
Upgrade to use generic-names v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "generic-names": "^1.0.1",
+    "generic-names": "^2.0.1",
     "glob-to-regexp": "^0.3.0",
     "icss-replace-symbols": "^1.0.2",
     "lodash": "^4.3.0",


### PR DESCRIPTION
[Solve ScopedName different of css-loader and css-modules-require-hook on Windows](https://github.com/css-modules/css-modules-require-hook/issues/119)